### PR TITLE
Give privilege to administrator automatically

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -28,6 +28,7 @@ if sqlite3 then sqlite3 = nil end
 minetest.register_privilege("ban_admin", {
 	description = "ban administrator",
 	give_to_singleplayer = false,
+	give_to_admin = true,
 })
 
 local WP = minetest.get_worldpath()


### PR DESCRIPTION
The `ban_admin` privilege will be given automatically to administrators.
Note that this function will break compatibility with MT `0.4.17.1` and below.